### PR TITLE
chore: align Renovate config to Giant Swarm presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "github>giantswarm/renovate-presets:default.json5",
+    "github>giantswarm/renovate-presets:lang-go.json5",
+  ],
+}


### PR DESCRIPTION
## Summary

- Replace minimal `renovate.json` (`config:recommended`) with `renovate.json5` extending standard Giant Swarm presets (`default.json5` + `lang-go.json5`)
- Brings in GS-specific labels, Go module grouping, `gomodTidy` post-updates, architect-orb automerge rules, and `zz_generated` path ignoring

Closes #44

## Self-review

- **code-reviewer**: No critical findings. Config is correct, preset references use proper `github>owner/repo:file` syntax, trailing commas are valid JSON5.
- **security-auditor**: No blocking findings. Local file has no injection surface, no dangerous Renovate options. Standard supply-chain trust delegation to `giantswarm/renovate-presets` (owned by the org, contents verified benign).

## Test plan

- [ ] Verify Renovate dependency dashboard issue updates correctly after next scheduled run
- [ ] Confirm no duplicate or broken PRs from Renovate after preset change

🤖 Generated with [Claude Code](https://claude.com/claude-code)