### PR TITLE
feat: add architect-orb CI pipeline, Dockerfile, and Helm chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,114 @@
+version: 2.1
+orbs:
+  architect: giantswarm/architect@6.14.1
+
+workflows:
+  build:
+    jobs:
+    - architect/go-build:
+        name: go-build-mcp-giantswarm-apps
+        binary: mcp-giantswarm-apps
+        filters:
+          tags:
+            only: /^v.*/
+
+    # Branch builds: amd64 only for faster PR feedback
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-registries
+        platforms: "linux/amd64"
+        requires:
+        - go-build-mcp-giantswarm-apps
+        filters:
+          branches:
+            ignore:
+            - main
+
+    # Tag builds: push multi-arch image to gsoci (primary registry).
+    # Chart push depends on this completing successfully.
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-gsoci-release
+        registries-data: "public gsoci.azurecr.io ACR_GSOCI_USERNAME ACR_GSOCI_PASSWORD true"
+        requires:
+        - go-build-mcp-giantswarm-apps
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+
+    # Tag builds: push multi-arch image to all registries (including China mirrors).
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-all-registries-release
+        requires:
+        - go-build-mcp-giantswarm-apps
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: build-mcp-giantswarm-apps-chart
+        app_catalog: giantswarm-catalog
+        app_catalog_test: giantswarm-test-catalog
+        chart: mcp-giantswarm-apps
+        push_to_appcatalog: false
+        push_to_oci_registry: false
+        persist_chart_archive: true
+        requires:
+        - go-build-mcp-giantswarm-apps
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore:
+            - main
+
+    - architect/run-tests-with-ats:
+        name: execute chart tests
+        requires:
+        - build-mcp-giantswarm-apps-chart
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore:
+            - main
+
+    # Branch: push chart after tests + amd64 image
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: push-mcp-giantswarm-apps-to-giantswarm-app-catalog
+        app_catalog: giantswarm-catalog
+        app_catalog_test: giantswarm-test-catalog
+        chart: mcp-giantswarm-apps
+        requires:
+        - execute chart tests
+        - push-to-registries
+        filters:
+          branches:
+            ignore:
+            - main
+
+    # Tag: push chart after tests + gsoci image
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: push-mcp-giantswarm-apps-to-giantswarm-app-catalog-release
+        app_catalog: giantswarm-catalog
+        app_catalog_test: giantswarm-test-catalog
+        chart: mcp-giantswarm-apps
+        requires:
+        - execute chart tests
+        - push-to-gsoci-release
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.circleci
+.github
+.cursor
+.goreleaser.yaml
+helm/
+docs/
+*.md
+.env*
+.vscode/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM --platform=$BUILDPLATFORM golang:1.25.0 AS builder
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
+    -ldflags "-w -extldflags '-static'" \
+    -o mcp-giantswarm-apps .
+
+FROM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm AS certs
+FROM scratch
+
+COPY --from=certs /etc/passwd /etc/passwd
+COPY --from=certs /etc/group /etc/group
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+COPY --from=builder /app/mcp-giantswarm-apps /mcp-giantswarm-apps
+USER giantswarm
+
+ENTRYPOINT ["/mcp-giantswarm-apps"]

--- a/helm/mcp-giantswarm-apps/.helmignore
+++ b/helm/mcp-giantswarm-apps/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/mcp-giantswarm-apps/Chart.yaml
+++ b/helm/mcp-giantswarm-apps/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: mcp-giantswarm-apps
+description: A Helm chart for mcp-giantswarm-apps - Model Context Protocol server for Giant Swarm app management
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/giantswarm/mcp-giantswarm-apps
+icon: https://s.giantswarm.io/app-icons/giantswarm/1/dark.svg
+sources:
+  - https://github.com/giantswarm/mcp-giantswarm-apps
+keywords:
+  - mcp
+  - giantswarm
+  - apps
+  - model-context-protocol
+maintainers:
+  - name: Giant Swarm
+    email: team-planeteers@giantswarm.io
+annotations:
+  io.giantswarm.application.team: team-planeteers
+  io.giantswarm.application.audience: customers
+  io.giantswarm.application.managed: "true"

--- a/helm/mcp-giantswarm-apps/templates/NOTES.txt
+++ b/helm/mcp-giantswarm-apps/templates/NOTES.txt
@@ -1,0 +1,14 @@
+1. mcp-giantswarm-apps has been deployed.
+
+   Transport: {{ .Values.mcpGiantswarmApps.transport }}
+
+2. Access the MCP server:
+{{- if eq .Values.service.type "ClusterIP" }}
+   kubectl port-forward svc/{{ include "mcp-giantswarm-apps.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+{{- end }}
+
+3. The server provides MCP tools for Giant Swarm app management including:
+   - App deployment and lifecycle management
+   - Catalog browsing and search
+   - Configuration management
+   - Organization operations

--- a/helm/mcp-giantswarm-apps/templates/_helpers.tpl
+++ b/helm/mcp-giantswarm-apps/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mcp-giantswarm-apps.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mcp-giantswarm-apps.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mcp-giantswarm-apps.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mcp-giantswarm-apps.labels" -}}
+helm.sh/chart: {{ include "mcp-giantswarm-apps.chart" . }}
+{{ include "mcp-giantswarm-apps.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mcp-giantswarm-apps.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-giantswarm-apps.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mcp-giantswarm-apps.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mcp-giantswarm-apps.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/mcp-giantswarm-apps/templates/deployment.yaml
+++ b/helm/mcp-giantswarm-apps/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-giantswarm-apps.fullname" . }}
+  labels:
+    {{- include "mcp-giantswarm-apps.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mcp-giantswarm-apps.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mcp-giantswarm-apps.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mcp-giantswarm-apps.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /mcp-giantswarm-apps
+          args:
+            - serve
+            - --transport={{ .Values.mcpGiantswarmApps.transport }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/mcp-giantswarm-apps/templates/rbac.yaml
+++ b/helm/mcp-giantswarm-apps/templates/rbac.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.serviceAccount.create .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "mcp-giantswarm-apps.fullname" . }}
+  labels:
+    {{- include "mcp-giantswarm-apps.labels" . | nindent 4 }}
+rules:
+  # Giant Swarm App Platform resources (read-only)
+  - apiGroups: ["application.giantswarm.io"]
+    resources: ["apps", "catalogs", "appcatalogentries"]
+    verbs: ["get", "list", "watch"]
+
+  # ConfigMaps for app configuration
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+
+  # Namespaces for organization discovery
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "mcp-giantswarm-apps.fullname" . }}
+  labels:
+    {{- include "mcp-giantswarm-apps.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "mcp-giantswarm-apps.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mcp-giantswarm-apps.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/mcp-giantswarm-apps/templates/service.yaml
+++ b/helm/mcp-giantswarm-apps/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-giantswarm-apps.fullname" . }}
+  labels:
+    {{- include "mcp-giantswarm-apps.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mcp-giantswarm-apps.selectorLabels" . | nindent 4 }}

--- a/helm/mcp-giantswarm-apps/templates/serviceaccount.yaml
+++ b/helm/mcp-giantswarm-apps/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mcp-giantswarm-apps.serviceAccountName" . }}
+  labels:
+    {{- include "mcp-giantswarm-apps.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/mcp-giantswarm-apps/values.schema.json
+++ b/helm/mcp-giantswarm-apps/values.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "Never", "IfNotPresent"]
+        },
+        "tag": {
+          "type": "string"
+        }
+      },
+      "required": ["registry", "repository", "pullPolicy"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "automount": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        }
+      }
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      }
+    },
+    "resources": {
+      "type": "object"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "mcpGiantswarmApps": {
+      "type": "object",
+      "properties": {
+        "transport": {
+          "type": "string",
+          "enum": ["stdio", "sse", "streamable-http"]
+        }
+      }
+    }
+  }
+}

--- a/helm/mcp-giantswarm-apps/values.yaml
+++ b/helm/mcp-giantswarm-apps/values.yaml
@@ -1,0 +1,67 @@
+# Default values for mcp-giantswarm-apps.
+
+replicaCount: 1
+
+image:
+  registry: gsoci.azurecr.io
+  repository: giantswarm/mcp-giantswarm-apps
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+rbac:
+  # Create RBAC resources (ClusterRole and ClusterRoleBinding)
+  create: true
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+    - ALL
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 256Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# MCP server configuration
+mcpGiantswarmApps:
+  # Transport type: stdio, sse, streamable-http
+  transport: streamable-http


### PR DESCRIPTION
## Summary

Adds standard Giant Swarm container build and deployment infrastructure to enable deploying mcp-giantswarm-apps on the app platform alongside muster.

- **Dockerfile**: Multi-stage build producing a minimal `scratch`-based image with static Go binary, CA certs, and non-root `giantswarm` user
- **`.circleci/config.yml`**: `giantswarm/architect@6.14.1` orb pipeline with `go-build`, `push-to-registries-multiarch` (amd64 for branches, multi-arch for tags), `push-to-app-catalog`, and `run-tests-with-ats` jobs
- **Helm chart** (`helm/mcp-giantswarm-apps/`): Deployment, Service, ServiceAccount, RBAC (least-privilege ClusterRole for GS App Platform CRDs, ConfigMaps, and Namespaces), values schema
- **`.dockerignore`**: Prevents leaking `.git`, `helm/`, `docs/` into build context

The existing GoReleaser workflow is retained for standalone binary releases.

### Self-review notes

- RBAC scoped to least privilege: read-only access to `application.giantswarm.io` CRDs, ConfigMaps, and Namespaces only (no Secrets at cluster scope)
- Security context: `scratch` image, non-root user, read-only rootfs, all capabilities dropped, seccomp `RuntimeDefault`
- Health probes use `tcpSocket` since the MCP server has no dedicated HTTP health endpoint
- Pipeline structure mirrors `mcp-kubernetes` reference implementation

Closes #45

## Test plan

- [ ] CircleCI pipeline triggers on branch push and builds successfully
- [ ] `architect/go-build` produces the `mcp-giantswarm-apps` binary
- [ ] Dev images are pushed to registries on branch builds
- [ ] Helm chart passes `architect/push-to-app-catalog` validation
- [ ] Chart tests pass via `run-tests-with-ats`
- [ ] Tag build produces multi-arch images and pushes to gsoci

🤖 Generated with [Claude Code](https://claude.com/claude-code)